### PR TITLE
Fix IDEA errors on kotlin.concurrent.Atomic* imports

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-//                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+                implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.0-RC")
                 implementation("org.jetbrains.kotlinx:atomicfu:0.20.2")
             }
         }


### PR DESCRIPTION
This PR fixes IDEA errors on kotlin.concurrent.Atomic* imports by explicitly specifying the version of the Kotlin stdlib in the gradle build script. 